### PR TITLE
[ #27 ] Added a confirmation popup dialog before deleting a transaction 

### DIFF
--- a/client/src/components/AddEditTransaction.js
+++ b/client/src/components/AddEditTransaction.js
@@ -2,14 +2,7 @@ import React, { useState } from "react";
 import { Form, Input, message, Modal, Select } from "antd";
 import Spinner from "./Spinner";
 import axios from "axios";
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-} from "@mui/material";
+import CustomDialog from './CustomDialog';
 
 function AddEditTransaction({
   setShowAddEditTransactionModal,
@@ -83,20 +76,6 @@ function AddEditTransaction({
     setDialog({ title: '', content: '' });
   };
 
-  const CustomDialog = ({ open, onClose, title, content }) => {
-    return (
-      <Dialog open={open} onClose={onClose}>
-        <DialogTitle>{title}</DialogTitle>
-        <DialogContent>
-          <DialogContentText>{content}</DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setOpen(false)}>Cancel</Button>
-        </DialogActions>
-      </Dialog>
-    );
-  };
-
   return (
     <Modal
       title={selectedItemForEdit ? 'Edit Transaction' : 'Add Transaction'}
@@ -104,7 +83,10 @@ function AddEditTransaction({
       onCancel={() => setShowAddEditTransactionModal(false)}
       footer={false}
     >
-      <CustomDialog open={open} onClose={resetDialog} title={dialog.title} content={dialog.content} />
+      <CustomDialog 
+        open={open} title={dialog.title} content={dialog.content} 
+        actions={[{displayName: 'Cancel', onClick: resetDialog}]}
+      />
       {loading && <Spinner />}
       <Form
         layout="vertical"

--- a/client/src/components/CustomDialog.js
+++ b/client/src/components/CustomDialog.js
@@ -1,0 +1,18 @@
+import React from "react";
+import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button } from '@mui/material';
+
+const CustomDialog = ({ open, title, content, actions }) => {
+    const dialogActions = actions.map((action) => (<Button onClick={action.onClick}>{action.displayName}</Button>));
+
+    return (
+      <Dialog open={open}>
+        <DialogTitle>{title}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{content}</DialogContentText>
+        </DialogContent>
+        <DialogActions> {dialogActions} </DialogActions>
+      </Dialog>
+    );
+  };
+
+export default CustomDialog;

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -13,11 +13,14 @@ import {
 } from "@ant-design/icons";
 import moment from "moment";
 import Analatics from "../components/Analatics";
+import CustomDialog from '../components/CustomDialog';
 const { RangePicker } = DatePicker;
 function Home() {
   const [showAddEditTransactionModal, setShowAddEditTransactionModal] =
     useState(false);
   const [selectedItemForEdit, setSelectedItemForEdit] = useState(null);
+  const [selectedItemForDelete, setSelectedItemForDelete] = useState(null);
+  const [isDeleteConfirmationDialogOpen, setIsDeleteConfirmationDialogOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [transactionsData, setTransactionsData] = useState([]);
   const [frequency, setFrequency] = useState("7");
@@ -46,20 +49,38 @@ function Home() {
     }
   };
 
-  const deleteTransaction = async (record) => {
+  const deleteTransaction = async () => {
     try {
       setLoading(true);
       await axios.post("/api/transactions/delete-transaction", {
-        transactionId: record._id,
+        transactionId: selectedItemForDelete._id,
       });
       message.success("Transaction Deleted successfully");
       getTransactions();
       setLoading(false);
+      setIsDeleteConfirmationDialogOpen(false)
     } catch (error) {
       setLoading(false);
       message.error("Something went wrong");
     }
   };
+
+  const DeleteTransactionConfirmationDialog = () => {
+    const message = "Are you sure you want to delete the transaction?";
+    const actions = [
+      { displayName: 'Cancel', onClick: () => setIsDeleteConfirmationDialogOpen(false) }, 
+      { displayName: 'Delete', onClick: deleteTransaction }
+    ];
+    return (
+      <CustomDialog open={isDeleteConfirmationDialogOpen} title={"Confirm Delete"} content={message} actions={actions} />
+    )
+  }
+
+  const onDeleteTransaction = (record) => {
+    setSelectedItemForDelete(record)
+    setIsDeleteConfirmationDialogOpen(true)
+  }
+
   useEffect(() => {
     getTransactions();
   }, [frequency, selectedRange, type]);
@@ -100,7 +121,7 @@ function Home() {
             />
             <DeleteOutlined
               className="mx-3"
-              onClick={() => deleteTransaction(record)}
+              onClick={() => onDeleteTransaction(record)}
             />
           </div>
         );
@@ -110,6 +131,7 @@ function Home() {
 
   return (
     <DefaultLayout>
+      <DeleteTransactionConfirmationDialog/>
       {loading && <Spinner />}
       <div className="filter d-flex justify-content-between align-items-center">
         <div className="d-flex">


### PR DESCRIPTION
Previously when a user tries to delete a transaction it will be directly deleted without asking for any confirmation. But it could lead to delete some entries unintentionally if a user clicks on the delete button.

As per the new implementation a pop dialog will come with a "Cancel" and "Delete" button when a user tries to delete.

<img width="450" alt="Screenshot 2022-10-18 at 2 16 42 PM" src="https://user-images.githubusercontent.com/56071561/196417052-92c43d68-a3fc-426f-b62a-b0eae1e81e83.png">

Corresponding issue - #27 


