### PR TITLE
[ #44 ] Transactions table pagination toggle implemented with page size 10

### DIFF
--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -60,6 +60,7 @@ function Home() {
       message.error("Something went wrong");
     }
   };
+
   useEffect(() => {
     getTransactions();
   }, [frequency, selectedRange, type]);
@@ -107,6 +108,8 @@ function Home() {
       },
     },
   ];
+
+  const getPaginationConfiguration = (pageSize) => transactionsData.length > pageSize ? {pageSize} : false
 
   return (
     <DefaultLayout>
@@ -172,7 +175,7 @@ function Home() {
       <div className="table-analtics">
         {viewType === "table" ? (
           <div className="table">
-            <Table columns={columns} dataSource={transactionsData} />
+            <Table columns={columns} dataSource={transactionsData} pagination={getPaginationConfiguration(10)}/>
           </div>
         ) : (
           <Analatics transactions={transactionsData} />


### PR DESCRIPTION
Previously the pagination icons will be shown irrespective of the number of transactions in the table for the current filter.
As per this new implementation it will be only shown when the transaction count is above the pagesize (that is configured to 10 for now). Screen shots are attached below.

When number of transaction is lesser than page size:
<img width="1630" alt="Screenshot 2022-10-31 at 11 44 26 AM" src="https://user-images.githubusercontent.com/56071561/198943817-c4fec1c9-0912-4091-9ec7-b6121cb94777.png">

When number of transaction is more than page size:
<img width="1624" alt="Screenshot 2022-10-31 at 11 44 06 AM" src="https://user-images.githubusercontent.com/56071561/198943895-408c73d6-2c8f-4909-ab47-3188c44be3f2.png">

Related issue: #44 