### PR TITLE
[ #44 ] Transactions table pagination text not visible issue fix

### DIFF
--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -60,6 +60,7 @@ function Home() {
       message.error("Something went wrong");
     }
   };
+
   useEffect(() => {
     getTransactions();
   }, [frequency, selectedRange, type]);
@@ -107,6 +108,8 @@ function Home() {
       },
     },
   ];
+
+  const getPaginationConfiguration = (pageSize) => transactionsData.length > pageSize ? {pageSize} : false
 
   return (
     <DefaultLayout>
@@ -172,7 +175,7 @@ function Home() {
       <div className="table-analtics">
         {viewType === "table" ? (
           <div className="table">
-            <Table columns={columns} dataSource={transactionsData} />
+            <Table columns={columns} dataSource={transactionsData} pagination={getPaginationConfiguration(10)}/>
           </div>
         ) : (
           <Analatics transactions={transactionsData} />

--- a/client/src/resources/transactions.css
+++ b/client/src/resources/transactions.css
@@ -55,3 +55,7 @@
         overflow-x: scroll;
     }
 }
+
+.ant-pagination-item a {
+    color: rgba(0, 0, 0, 0.85) !important;
+  }


### PR DESCRIPTION
Previously the transaction table pagination text was not visible due to some issue with the css and it has been fixed by this changes. Attaching the screenshot.

<img width="872" alt="Screenshot 2022-10-31 at 12 01 26 PM" src="https://user-images.githubusercontent.com/56071561/198946284-9a36753c-ccb5-447d-9719-6d06affae09a.png">


Related issue: #44 