### PR TITLE
[ #42 ] Fix to show 0% in analytics, when there are no transactions for the user

### DIFF
--- a/client/src/components/Analatics.js
+++ b/client/src/components/Analatics.js
@@ -10,9 +10,9 @@ function Analatics({ transactions }) {
     (transaction) => transaction.type === "expense"
   );
   const totalIncomeTransactionsPercentage =
-    (totalIncomeTransactions.length / totalTransactions) * 100;
+    totalTransactions === 0 ? 0 : (totalIncomeTransactions.length / totalTransactions) * 100;
   const totalExpenceTransactionsPercentage =
-    (totalExpenceTransactions.length / totalTransactions) * 100;
+    totalTransactions === 0 ? 0 : (totalExpenceTransactions.length / totalTransactions) * 100;
 
   const totalTurnover = transactions.reduce(
     (acc, transaction) => acc + transaction.amount,
@@ -26,9 +26,9 @@ function Analatics({ transactions }) {
     .reduce((acc, transaction) => acc + transaction.amount, 0);
   console.log(totalExpenceTurnover);
   const totalIncomeTurnoverPercentage =
-    (totalIncomeTurnover / totalTurnover) * 100;
+    totalTurnover === 0 ? 0 : (totalIncomeTurnover / totalTurnover) * 100 ;
   const totalExpenceTurnoverPercentage =
-    (totalExpenceTurnover / totalTurnover) * 100;
+    totalTurnover === 0 ? 0 : (totalExpenceTurnover / totalTurnover) * 100;
 
   const categories = [
     "salary",


### PR DESCRIPTION
@princid Implemented basic enhancement in the analytics page when there are no transaction for the user

This the page before fixing it

<img width="1174" alt="Screenshot 2022-10-26 at 10 26 31 PM" src="https://user-images.githubusercontent.com/58027046/198958205-5a1d52fa-f27d-42b7-9bc4-a8f8120d9163.png">

and after fixing, it will show 0% when there are no transactions as shown below

<img width="1186" alt="Screenshot 2022-10-31 at 1 14 36 PM" src="https://user-images.githubusercontent.com/58027046/198958434-74a9f3bb-e19a-4452-98a4-dfd8c7e581b9.png">


